### PR TITLE
Create directories in build script if they don't exist

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,16 +3,22 @@
 CODE_PATH=code
 BUILD_PATH=build
 ASSETS_PATH=data
+TEMP_PATH=temp
 
 # OPTIMIZE_SWITCHES=""
 OPTIMIZE_SWITCHES="-O"
+
+mkdir -p $BUILD_PATH
 
 swiftc -g $OPTIMIZE_SWITCHES $CODE_PATH/Math.swift $CODE_PATH/main.swift -o $BUILD_PATH/main
 
 rm ./temp/*
 rm ./out.mp4
+
+mkdir -p $TEMP_PATH
+
 $BUILD_PATH/main
 # open temp/out_001.ppm
-ffmpeg -i ./temp/out_%03d.ppm -c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p -c:a copy out.mp4
+ffmpeg -i ./$TEMP_PATH/out_%03d.ppm -c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p -c:a copy out.mp4
 
 exit 0


### PR DESCRIPTION
I faced errors when using the build script, specifically that the build/ and temp/ directories didn't exist. This just fixes that by creating them if they don't exist already.